### PR TITLE
feat: Making normalized ECF default

### DIFF
--- a/src/_ext.cpp
+++ b/src/_ext.cpp
@@ -13,6 +13,7 @@
 #include <fastjet/GhostedAreaSpec.hh>
 #include <fastjet/JetDefinition.hh>
 #include <fastjet/PseudoJet.hh>
+#include <fastjet/contrib/SoftDrop.hh>
 #include <fastjet/contrib/EnergyCorrelator.hh>
 #include <fastjet/contrib/LundGenerator.hh>
 
@@ -1581,8 +1582,12 @@ PYBIND11_MODULE(_ext, m) {
         Returns:
           pt, eta, phi, m of inclusive jets.
       )pbdoc")
+      /*.def("to_numpy_softdrop",
+      [](const output_wrapper ow, double beta, double symmetry_cut, ){
+
+      })*/
       .def("to_numpy_energy_correlators",
-      [](const output_wrapper ow, const int n_jets = 1, const double beta = 1, double npoint = 0, int angles = 0, double alpha = 0, std::string func = "generalized") {
+      [](const output_wrapper ow, const int n_jets = 1, const double beta = 1, double npoint = 0, int angles = 0, double alpha = 0, std::string func = "generalized", bool normalized = true) {
         auto css = ow.cse;
         int64_t len = css.size();
 
@@ -1623,8 +1628,10 @@ PYBIND11_MODULE(_ext, m) {
           energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorU2>(beta);}
         else if (func == "u3") {
           energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorU3>(beta);}
-        else if (func == "generic") {
+        else if (func == "generic" && normalized == false) {
           energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelator>(npoint, beta);} // The generic energy correlator is not normalized; i.e. does not use a momentum fraction when being calculated.
+        else if (func == "generic" && normalized == true) {
+          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorGeneralized>(angles, npoint, beta);}
 
         std::vector<double> ECF_vec;
 

--- a/src/fastjet/__init__.py
+++ b/src/fastjet/__init__.py
@@ -360,9 +360,10 @@ class ClusterSequence:  # The super class
         njets: int = 1,
         beta: int = 1,
         npoint: int = 0,
-        angles: int = 0,
+        angles: int = -1,
         alpha=0,
         func="generalized",
+        normalized=True,
     ) -> ak.Array:
         """Returns the energy correlator of each exclusive jet.
 

--- a/src/fastjet/_generalevent.py
+++ b/src/fastjet/_generalevent.py
@@ -440,7 +440,7 @@ class _classgeneralevent:
         return res
 
     def exclusive_jets_energy_correlator(
-        self, njets=1, n_point=0, angle: int = 0, beta=1, alpha=0, func="generalized"
+        self, njets=1, n_point=0, angles: int = -1, beta=1, alpha=0, func="generalized", normalized=True,
     ):
         if njets <= 0:
             raise ValueError("Njets cannot be <= 0")

--- a/src/fastjet/_multievent.py
+++ b/src/fastjet/_multievent.py
@@ -193,12 +193,12 @@ class _classmultievent:
         return out
 
     def exclusive_jets_energy_correlator(
-        self, njets=1, beta=1, npoint=0, angles=0, alpha=0, func="generalized"
+        self, njets=1, beta=1, npoint=0, angles=-1, alpha=0, func="generalized", normalized=True,
     ):
         if njets <= 0:
             raise ValueError("Njets cannot be <= 0")
         np_results = self._results.to_numpy_energy_correlators(
-            njets, beta, npoint, angles, alpha, func
+            njets, beta, npoint, angles, alpha, func, normalized,
         )
         out = ak.Array(ak.contents.NumpyArray(np_results))
         return out

--- a/src/fastjet/_pyjet.py
+++ b/src/fastjet/_pyjet.py
@@ -144,10 +144,10 @@ class AwkwardClusterSequence(ClusterSequence):
         return self._internalrep.exclusive_jets_constituents(njets)
 
     def exclusive_jets_energy_correlator(
-        self, njets=1, beta=1, npoint=0, angles=0, alpha=0, func="generalized"
+        self, njets=1, beta=1, npoint=0, angles=-1, alpha=0, func="generalized", normalized=True
     ):
         return self._internalrep.exclusive_jets_energy_correlator(
-            njets, beta, npoint, angles, alpha, func
+            njets, beta, npoint, angles, alpha, func, normalized,
         )
 
     def exclusive_jets_lund_declusterings(self, njets=10):
@@ -429,7 +429,7 @@ class DaskAwkwardClusterSequence(ClusterSequence):
         return _dak_dispatch(self, "exclusive_jets_constituents", njets=njets)
 
     def exclusive_jets_energy_correlator(
-        self, njets=1, beta=1, npoint=0, angles=0, alpha=0, func="generalized"
+        self, njets=1, beta=1, npoint=0, angles=-1, alpha=0, func="generalized", normalized=False,
     ):
         return _dak_dispatch(
             self,
@@ -440,6 +440,7 @@ class DaskAwkwardClusterSequence(ClusterSequence):
             angles=angles,
             alpha=alpha,
             func=func,
+            normalized=normalized,
         )
 
     def exclusive_jets_lund_declusterings(self, njets=10):

--- a/src/fastjet/_singleevent.py
+++ b/src/fastjet/_singleevent.py
@@ -181,13 +181,13 @@ class _classsingleevent:
         return out[0]
 
     def exclusive_jets_energy_correlator(
-        self, njets=1, beta=1, npoint=0, angles=0, alpha=0, func="generalized"
+        self, njets=1, beta=1, npoint=0, angles=-1, alpha=0, func="generalized", normalized=True,
     ):
         if njets <= 0:
             raise ValueError("Njets cannot be <= 0")
 
         np_results = self._results.to_numpy_energy_correlators(
-            njets, beta, npoint, angles, alpha, func
+            njets, beta, npoint, angles, alpha, func, normalized,
         )
         out = ak.Array(ak.contents.NumpyArray(np_results))
         return out[0]

--- a/src/fastjet/_singleevent.py
+++ b/src/fastjet/_singleevent.py
@@ -189,7 +189,6 @@ class _classsingleevent:
         np_results = self._results.to_numpy_energy_correlators(
             njets, beta, npoint, angles, alpha, func
         )
-        off = np_results[-1]
         out = ak.Array(ak.contents.NumpyArray(np_results))
         return out[0]
 


### PR DESCRIPTION
Included a change to the def in _ext.cpp that uses Generalized with arg angles=-1 by default, so the result is the normalized ECF. Giving normalized=False returns the original ECF.